### PR TITLE
Change way to visualize detections.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,9 +11,9 @@ add_definitions(-std=c++11 -DGAZR_VERSION=${VERSION})
 find_package(dlib REQUIRED)
 include_directories(${dlib_INCLUDE_DIRS})
 
-option(DEBUG "Enable debug visualizations" ON)
-option(WITH_TOOLS "Compile sample tools" ON)
-option(WITH_ROS "Build ROS nodes" OFF)
+option(DEBUG_OUTPUT "Enable debug visualizations" OFF)
+option(WITH_TOOLS "Compile sample tools" OFF)
+option(WITH_ROS "Build ROS nodes" ON)
 
 if(WITH_ROS)
 
@@ -32,7 +32,7 @@ if(WITH_ROS)
 
 endif()
 
-if(DEBUG)
+if(DEBUG_OUTPUT)
     find_package(OpenCV COMPONENTS core imgproc calib3d highgui REQUIRED)
 else()
     find_package(OpenCV COMPONENTS core imgproc calib3d REQUIRED)
@@ -53,10 +53,9 @@ if(WITH_ROS)
     )
 endif()
 
-if(DEBUG)
+if(DEBUG_OUTPUT)
     add_definitions(-DHEAD_POSE_ESTIMATION_DEBUG)
 endif()
-
 include_directories(${OpenCV_INCLUDE_DIRS})
 
 add_library(gazr SHARED src/head_pose_estimation.cpp)

--- a/launch/3d_facial_features.launch
+++ b/launch/3d_facial_features.launch
@@ -1,13 +1,13 @@
 <launch>
+    <arg name="model" default="$(find gazr)/share/shape_predictor_68_face_landmarks.dat"/>
 
-    <arg name="model" />
-
-    <group ns="participant_purple">
-        <node pkg="3d_face_features" type="run" name="face_features_3d" output="screen" >
+    <group ns="camera">
+        <node pkg="gazr" type="estimate" name="face_features_3d" output="screen" >
             <param name="face_model" value="$(arg model)" />
-            <remap from="rgb" to="rgb/image_rect_color" />
-            <remap from="camera_info" to="rgb/camera_info" />
-            <remap from="depth" to="depth_registered/sw_registered/image_rect_raw" />
+            <param name="with_depth" value="true" />
+            <remap from="rgb" to="camera/rgb/image_rect_color" />
+            <remap from="camera_info" to="camera/rgb/camera_info" />
+            <remap from="depth" to="camera/depth_registered/sw_registered/image_rect_raw" />
         </node>
     </group>
 </launch>

--- a/launch/gazr.launch
+++ b/launch/gazr.launch
@@ -11,7 +11,7 @@
 
     <group ns="$(arg ns)">
         <node pkg="gazr" type="estimate" name="gazr" output="screen" required="true" >
-            <param name="face_model" value="$(find gazr)/shape_predictor_68_face_landmarks.dat" />
+            <param name="face_model" value="$(find gazr)/share/shape_predictor_68_face_landmarks.dat" />
             <param name="prefix" value="$(arg face_prefix)" />
             <param name="with_depth" value="$(arg with_depth)" />
             <remap from="rgb" to="$(arg rgb)"/>

--- a/launch/gazr_gscam.launch
+++ b/launch/gazr_gscam.launch
@@ -12,7 +12,7 @@
   </node>
 
   <node pkg="gazr" type="estimate" name="gazr">
-    <param name="face_model" value="$(find gazr)/shape_predictor_68_face_landmarks.dat" />
+    <param name="face_model" value="$(find gazr)/share/shape_predictor_68_face_landmarks.dat" />
     <remap from="/image" to="/camera/image_raw"/>
   </node>
 

--- a/src/facialfeaturescloud.hpp
+++ b/src/facialfeaturescloud.hpp
@@ -21,8 +21,6 @@
  */
 class FacialFeaturesPointCloudPublisher {
 
-    typedef sensor_msgs::PointCloud2 PointCloud;
-
 public:
     FacialFeaturesPointCloudPublisher(ros::NodeHandle& rosNode,
                                       const std::string& prefix,
@@ -35,42 +33,44 @@ private:
 
     template<typename T>
     void makeFeatureCloud(const std::vector<cv::Point> points2d,
-                                 const sensor_msgs::ImageConstPtr& depth_msg,
-                                 PointCloud::Ptr& cloud_msg);
-
-    ros::NodeHandle& rosNode;
+                          const sensor_msgs::ImageConstPtr& depth_msg,
+                          sensor_msgs::PointCloud2Ptr& cloud_msg);
 
     image_geometry::PinholeCameraModel cameramodel;
 
     cv::Mat inputImage;
-    HeadPoseEstimation estimator;
-
-
-    // Subscriptions
-    /////////////////////////////////////////////////////////
-    std::shared_ptr<image_transport::ImageTransport> rgb_it_, depth_it_;
-    image_transport::SubscriberFilter sub_depth_, sub_rgb_;
-    message_filters::Subscriber<sensor_msgs::CameraInfo> sub_info_;
-    typedef message_filters::sync_policies::ApproximateTime<sensor_msgs::Image, sensor_msgs::Image, sensor_msgs::CameraInfo> SyncPolicy;
-    typedef message_filters::sync_policies::ExactTime<sensor_msgs::Image, sensor_msgs::Image, sensor_msgs::CameraInfo> ExactSyncPolicy;
-    typedef message_filters::Synchronizer<SyncPolicy> Synchronizer;
-    typedef message_filters::Synchronizer<ExactSyncPolicy> ExactSynchronizer;
-    std::shared_ptr<Synchronizer> sync_;
-    std::shared_ptr<ExactSynchronizer> exact_sync_;
-
-    // Publishers
-    /////////////////////////////////////////////////////////
-    image_transport::Publisher pub;
-
-    // prefix prepended to TF frames generated for each frame
-    std::string facePrefix;
-
-    ros::Publisher nb_detected_faces_pub;
-
-    ros::Publisher facial_features_pub;
 
     tf::TransformBroadcaster br;
     tf::Transform transform;
 
+    HeadPoseEstimation estimator;
+
+    // prefix prepended to TF frames generated for each frame
+    std::string facePrefix;
+
+    // Subscriptions
+    /////////////////////////////////////////////////////////
+    std::shared_ptr<image_transport::ImageTransport> rgb_it_;
+    std::shared_ptr<image_transport::ImageTransport> depth_it_;
+    image_transport::SubscriberFilter sub_depth_;
+    image_transport::SubscriberFilter sub_rgb_;
+    message_filters::Subscriber<sensor_msgs::CameraInfo> sub_info_;
+
+    // Publishers
+    /////////////////////////////////////////////////////////
+    ros::Publisher nb_detected_faces_pub;
+
+    ros::Publisher facial_features_pub;
+    
+#ifdef HEAD_POSE_ESTIMATION_DEBUG
+    image_transport::Publisher pub;
+#endif
+
+    // typedef message_filters::sync_policies::ApproximateTime<sensor_msgs::Image, sensor_msgs::Image, sensor_msgs::CameraInfo> SyncPolicy;
+    typedef message_filters::sync_policies::ExactTime<sensor_msgs::Image, sensor_msgs::Image, sensor_msgs::CameraInfo> ExactSyncPolicy;
+    // typedef message_filters::Synchronizer<SyncPolicy> Synchronizer;
+    typedef message_filters::Synchronizer<ExactSyncPolicy> ExactSynchronizer;
+    // std::shared_ptr<Synchronizer> sync_;
+    std::shared_ptr<ExactSynchronizer> exact_sync_;
 };
 

--- a/src/facialfeaturescloud.hpp
+++ b/src/facialfeaturescloud.hpp
@@ -34,7 +34,7 @@ public:
 private:
 
     template<typename T>
-    cv::Point3f makeFeatureCloud(const std::vector<cv::Point> points2d,
+    void makeFeatureCloud(const std::vector<cv::Point> points2d,
                                  const sensor_msgs::ImageConstPtr& depth_msg,
                                  PointCloud::Ptr& cloud_msg);
 
@@ -60,6 +60,7 @@ private:
 
     // Publishers
     /////////////////////////////////////////////////////////
+    image_transport::Publisher pub;
 
     // prefix prepended to TF frames generated for each frame
     std::string facePrefix;

--- a/src/head_pose_estimation.hpp
+++ b/src/head_pose_estimation.hpp
@@ -64,13 +64,15 @@ public:
 
     std::vector<head_pose> poses() const;
 
+    /** Returns an augmented image with the detected facial features and head pose drawn in.
+     * 
+     * Leave either detected_features or detected_poses empty to skip drawing the respective detections.
+     */
+    cv::Mat drawDetections(const cv::Mat& original_image, const std::vector<std::vector<cv::Point>>& detected_features, const std::vector<head_pose>& detected_poses);
+
     float focalLength;
     float opticalCenterX;
     float opticalCenterY;
-
-#ifdef HEAD_POSE_ESTIMATION_DEBUG
-    mutable cv::Mat _debug;
-#endif
 
 private:
 
@@ -83,6 +85,10 @@ private:
 
     std::vector<dlib::full_object_detection> shapes;
 
+
+    void drawFeatures(const std::vector<std::vector<cv::Point>>& detected_features, cv::Mat& result) const;
+
+    void drawPose(const head_pose& detected_pose, size_t face_idx, cv::Mat& result) const;
 
     /** Return the point corresponding to the dictionary marker.
     */

--- a/src/ros_head_pose_estimator.cpp
+++ b/src/ros_head_pose_estimator.cpp
@@ -52,10 +52,12 @@ void HeadPoseEstimator::detectFaces(const sensor_msgs::ImageConstPtr& rgb_msg,
     *                      Faces detection                           *
     ********************************************************************/
 
-    estimator.update(rgb);
+    auto all_features = estimator.update(rgb);
 
     auto poses = estimator.poses();
+#ifdef HEAD_POSE_ESTIMATION_DEBUG
     ROS_INFO_STREAM(poses.size() << " faces detected.");
+#endif
 
     std_msgs::Char nb_faces;
     nb_faces.data = poses.size();
@@ -105,7 +107,7 @@ void HeadPoseEstimator::detectFaces(const sensor_msgs::ImageConstPtr& rgb_msg,
 #ifdef HEAD_POSE_ESTIMATION_DEBUG
     if(pub.getNumSubscribers() > 0) {
         ROS_INFO_ONCE("Starting to publish face tracking output for debug");
-        auto debugmsg = cv_bridge::CvImage(msg->header, "bgr8", estimator._debug).toImageMsg();
+        auto debugmsg = cv_bridge::CvImage(rgb_msg->header, "bgr8", estimator.drawDetections(rgb, all_features, poses)).toImageMsg();
         pub.publish(debugmsg);
     }
 #endif

--- a/tools/estimate_head_direction.cpp
+++ b/tools/estimate_head_direction.cpp
@@ -111,7 +111,7 @@ int main(int argc, char **argv)
         }
 
 
-        estimator.update(frame);
+        auto all_features = estimator.update(frame);
 
 
         auto poses = estimator.poses();
@@ -150,7 +150,7 @@ int main(int argc, char **argv)
         cout << "}\n" << flush;
 
         if (show_frame) {
-            imshow("headpose", estimator._debug);
+            imshow("headpose", estimator.drawDetections(frame, all_features, poses));
             if(use_camera) {
                 waitKey(10);
             }

--- a/tools/estimate_head_pose_from_image_or_file.cpp
+++ b/tools/estimate_head_pose_from_image_or_file.cpp
@@ -41,9 +41,10 @@ void estimate_head_pose_on_frameFileName(const std::string& frameFileName, HeadP
 
     auto nbfaces = 0;
 
-    for(size_t i = 0; i < NB_TESTS; i++) {
+    for(size_t i = 0; i < NB_TESTS - 1; i++) {
         estimator.update(img);
     }
+    auto all_features = estimator.update(img);
 
     // auto t_detection = getTickCount();
 
@@ -70,6 +71,11 @@ void estimate_head_pose_on_frameFileName(const std::string& frameFileName, HeadP
         cout << "Head pose not calculated!" << endl;
     }
 
+    #ifdef HEAD_POSE_ESTIMATION_DEBUG
+        static size_t img_id = 0;
+        imwrite(std::to_string(img_id) + "_head_pose.png", estimator.drawDetections(img, all_features, poses));
+        img_id += 1;
+    #endif
 }
 
 
@@ -145,9 +151,5 @@ int main(int argc, char **argv)
     // cout << "Face feature detection: " <<((t_detection-t_start) / NB_TESTS) /getTickFrequency() * 1000. << "ms;";
     // cout << "Pose estimation: " <<((t_end-t_detection) / NB_TESTS) /getTickFrequency() * 1000. << "ms;";
     cout << "Total time: " << (t_end-t_start) / getTickFrequency() * 1000. << "ms" << endl;
-
-#ifdef HEAD_POSE_ESTIMATION_DEBUG
-    imwrite("head_pose.png", estimator._debug);
-#endif
 
 }

--- a/tools/show_head_pose.cpp
+++ b/tools/show_head_pose.cpp
@@ -91,13 +91,13 @@ int main(int argc, char **argv)
 
         auto t_start = getTickCount();
 
-        estimator.update(frame);
-        estimator.poses();
+        auto all_features = estimator.update(frame);
+        auto poses = estimator.poses();
 
         auto t_end = getTickCount();
         cout << "Processing time for this frame: " << (t_end-t_start) / getTickFrequency() * 1000. << "ms" << endl;
 
-        imshow("headpose", estimator._debug);
+        imshow("headpose", estimator.drawDetections(frame, all_features, poses));
         if (waitKey(10) >= 0) break;
 
     }


### PR DESCRIPTION
Issue #15 was caused by errors in using the `_debug` member variable, such as
forgetting to wrap access to it in `#ifdef DEBUG`. A couple of build problems were
discovered, when the `DEBUG` flag was either set or unset, resulting from such
logical errors in the code. This issue has been resolved, and the code made a
little cleaner, by refactoring the way detections are visualized.

Instead of modifying `_debug`  whenever facial features or
head poses are detected, define member functions for drawing the
most recent detections onto a copy of the original image. Detections can be
visualized even when the flag to enable debug visualizations is not set, as in
`show_head_pose.cpp`.

Rename the flag so as not to conflate the meaning of `DEBUG`, which
conventionally refers to *Debug* vs. *Release* compilation mode.
One may want to compile the package in Release mode and still be
able to visualize detections.

NOTE: visualization of numeric IDs of facial features, as well as
reprojected points has been commented out due to personal preference.

Resolves #15.