### PR TITLE
Fix CMake warnings concerning `dlib_{INCLUDE_DIRS,LIBRARIES}`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,7 +59,7 @@ endif()
 include_directories(${OpenCV_INCLUDE_DIRS})
 
 add_library(gazr SHARED src/head_pose_estimation.cpp)
-target_link_libraries(gazr ${dlib_LIBRARIES} ${OpenCV_LIBRARIES})
+target_link_libraries(gazr dlib::dlib ${OpenCV_LIBRARIES})
 
 if(WITH_ROS)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ set(VERSION ${CPACK_PACKAGE_VERSION_MAJOR}.${CPACK_PACKAGE_VERSION_MINOR}.${CPAC
 add_definitions(-std=c++11 -DGAZR_VERSION=${VERSION})
 
 find_package(dlib REQUIRED)
-include_directories(${dlib_INCLUDE_DIRS})
+include_directories(dlib::dlib)
 
 option(DEBUG_OUTPUT "Enable debug visualizations" OFF)
 option(WITH_TOOLS "Compile sample tools" OFF)


### PR DESCRIPTION
Silence the following CMake warnings:

    CMake Warning at /usr/lib/x86_64-linux-gnu/cmake/dlib/dlibConfig.cmake:42 (message):
      The variable 'dlib_INCLUDE_DIRS' is deprecated! Instead, simply use
      target_link_libraries(your_app dlib::dlib).  See
      http://dlib.net/examples/CMakeLists.txt.html for an example.
 
 and

    CMake Warning at /usr/lib/x86_64-linux-gnu/cmake/dlib/dlibConfig.cmake:42 (message):
      The variable 'dlib_LIBRARIES' is deprecated! Instead, simply use
      target_link_libraries(your_app dlib::dlib).  See
      http://dlib.net/examples/CMakeLists.txt.html for an example.