### PR TITLE
Add OpenCV header for missing definition of CV_AA

### DIFF
--- a/src/head_pose_estimation.cpp
+++ b/src/head_pose_estimation.cpp
@@ -3,6 +3,7 @@
 
 #include <opencv2/calib3d/calib3d.hpp>
 #include <opencv2/imgproc/imgproc.hpp>
+#include <opencv2/imgproc/imgproc_c.h>
 
 #ifdef HEAD_POSE_ESTIMATION_DEBUG
 #include <iostream>


### PR DESCRIPTION
Avoid the following compilation error by adding the relevant header:

    error: ‘CV_AA’ was not declared in this scope; did you mean ‘CV_MSA’?