### PR TITLE
Circumvent dlib-opencv mismatch compilation error

### DIFF
--- a/src/head_pose_estimation.cpp
+++ b/src/head_pose_estimation.cpp
@@ -45,7 +45,10 @@ std::vector<std::vector<Point>> HeadPoseEstimation::update(cv::InputArray _image
 #endif
     }
 
-    current_image = cv_image<bgr_pixel>(image);
+    // intermediate value to avoid potential compilation error:
+    //     conversion from ‘const cv::Mat’ to non-scalar type ‘IplImage’
+    auto ipl_img = cvIplImage(image);
+    current_image = cv_image<bgr_pixel>(&ipl_img);
 
     faces = detector(current_image);
 


### PR DESCRIPTION
Avoid the following compilation failure arising from a mismatch between particular versions of `dlib` and OpenCV (see davisking/dlib#1949):

        In file included from /usr/include/dlib/opencv.h:10,
                         from src/head_pose_estimation.hpp:5,
                         from src/head_pose_estimation.cpp:11:
        /usr/include/dlib/opencv/cv_image.h: In instantiation of ‘dlib::cv_image<pixel_type>::cv_image(cv::Mat) [with pixel_type = dlib::bgr_pixel]’:
        src/head_pose_estimation.cpp:48:46:   required from here
        /usr/include/dlib/opencv/cv_image.h:37:29: error: conversion from ‘const cv::Mat’ to non-scalar type ‘IplImage’ requested
           37 |             IplImage temp = img;